### PR TITLE
Fix range mc raptor and unique journeys

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,16 +19,15 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
 CSV = "^0.10.14"
-DataFrames = "^1.6.1"
-JuliaFormatter = "^1.0.56"
-JET = "0.9.6"
+DataFrames = "^1.7.0"
+JuliaFormatter = "^1.0.60"
+JET = "0.9.9"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 StaticLint = "b3cc710f-9c33-5bdb-a03d-a94903873e97"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StaticLint", "Aqua", "BenchmarkTools"]
+test = ["Test", "StaticLint", "Aqua"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
 CSV = "^0.10.14"
-DataFrames = "^1.7.0"
+DataFrames = "^1.6.1"
 JuliaFormatter = "^1.0.60"
 JET = "0.9.9"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ See [Documentation](https://tjebbeh.github.io/Raptor.jl/) for instructions on ho
 - Improve parallelization
 - Clean up/refactor?
 - Improve Documentation (o.a., more doc strings api, general timetable)
+- Write output
 - Register package

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [Documentation](https://tjebbeh.github.io/Raptor.jl/) for instructions on ho
 ## TODO:
 - More functional unittests
 - Make config with threshold, fare, default footpaths
+- Optimize
 - Improve parallelization
 - Clean up/refactor?
 - Improve Documentation (o.a., more doc strings api, general timetable)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Raptor = "b090d68a-8df8-4aea-b865-41f2ccd73d3a"
 
 [compat]
-Documenter = "^1.5"
+Documenter = "^1.7"
 Plots="^1.40"

--- a/src/raptor_algorithm/construct_journeys.jl
+++ b/src/raptor_algorithm/construct_journeys.jl
@@ -115,11 +115,11 @@ end
 """Remove duplicate journeys"""
 function remove_duplicate_journeys!(journeys_to_destination::Dict{Station,Vector{Journey}})
     for destination in keys(journeys_to_destination)
-        unique!(journeys_to_destination[destination])
+        journeys_to_destination[destination] = unique(journeys_to_destination[destination])
     end
 end
 
-"""sort duplicate journeys"""
+"""Sort journeys"""
 function sort_journeys!(journeys_to_destination::Dict{Station,Vector{Journey}})
     for destination in keys(journeys_to_destination)
         sort!(journeys_to_destination[destination]; by=x -> x.legs[1].departure_time)
@@ -130,8 +130,10 @@ is_transfer(leg::JourneyLeg) = leg.to_stop.station_name == leg.from_stop.station
 
 function Base.show(io::IO, journey::Journey)
     for leg in journey.legs
-        printstyled("| "; bold=true, color=:yellow)
-        println(io, leg)
+        if !is_transfer(leg)
+            printstyled("| "; bold=true, color=:yellow)
+            println(io, leg)
+        end
     end
 end
 

--- a/src/raptor_algorithm/construct_journeys.jl
+++ b/src/raptor_algorithm/construct_journeys.jl
@@ -50,8 +50,11 @@ function last_legs(destination::Station, bag_last_round)
     journeys = Journey[]
     for option in station_bag.options
         # find the stop of the station at which the option arrives
-        to_stop = only(filter(s -> option in bag_last_round[s].options, to_stops)) 
-        clear_how_to_get_there = !isnothing(option.from_stop) && !isnothing(option.from_departure_time) && !isnothing(option.trip_to_station)
+        to_stop = only(filter(s -> option in bag_last_round[s].options, to_stops))
+        clear_how_to_get_there =
+            !isnothing(option.from_stop) &&
+            !isnothing(option.from_departure_time) &&
+            !isnothing(option.trip_to_station)
         if clear_how_to_get_there
             leg = JourneyLeg(option, to_stop)
             push!(journeys, Journey([leg]))

--- a/src/raptor_algorithm/journey_structs.jl
+++ b/src/raptor_algorithm/journey_structs.jl
@@ -1,4 +1,4 @@
-struct JourneyLeg
+struct JourneyLeg <: Comparable
     from_stop::Stop
     to_stop::Stop
     departure_time::DateTime
@@ -7,6 +7,30 @@ struct JourneyLeg
     trip::Trip
     to_label::Label # criteria for arriving at to_stop
 end
+leg_as_string(leg::JourneyLeg) = 
+    join(string.(
+        [getfield(leg, :from_stop).id,
+        getfield(leg, :to_stop).id,
+        getfield(leg, :departure_time),
+        getfield(leg, :arrival_time),
+        getfield(leg, :fare),
+        getfield(leg, :trip).name
+        ],
+        "_"
+    )
+)
+# hash legs to make unique work
+Base.hash(leg::JourneyLeg, h::UInt) = hash(
+    (
+        getfield(leg, :from_stop),
+        getfield(leg, :to_stop),
+        getfield(leg, :departure_time),
+        getfield(leg, :arrival_time),
+        getfield(leg, :fare),
+        getfield(leg, :trip).name,
+    )
+    , h
+)
 
 """Construct journey leg from option and to_stop"""
 function JourneyLeg(option::Option, to_stop::Stop)
@@ -28,7 +52,7 @@ struct Journey <: Comparable
     legs::Vector{JourneyLeg}
 end
 # hash journey legs to make unique work
-Base.hash(journey::Journey) = hash(getfield(journey, :legs))
+Base.hash(journey::Journey, h::UInt) = hash(leg_as_string.(getfield(journey, :legs)), h)
 
 function Journeys(options::Vector{Option}, to_stop::Stop)
     return [Journey([leg]) for leg in JourneyLegs(options, to_stop)]

--- a/src/raptor_algorithm/journey_structs.jl
+++ b/src/raptor_algorithm/journey_structs.jl
@@ -7,30 +7,35 @@ struct JourneyLeg <: Comparable
     trip::Trip
     to_label::Label # criteria for arriving at to_stop
 end
-leg_as_string(leg::JourneyLeg) = 
-    join(string.(
-        [getfield(leg, :from_stop).id,
-        getfield(leg, :to_stop).id,
-        getfield(leg, :departure_time),
-        getfield(leg, :arrival_time),
-        getfield(leg, :fare),
-        getfield(leg, :trip).name
-        ],
-        "_"
+function leg_as_string(leg::JourneyLeg)
+    return join(
+        string.(
+            [
+                getfield(leg, :from_stop).id,
+                getfield(leg, :to_stop).id,
+                getfield(leg, :departure_time),
+                getfield(leg, :arrival_time),
+                getfield(leg, :fare),
+                getfield(leg, :trip).name,
+            ],
+            "_",
+        ),
     )
-)
+end
 # hash legs to make unique work
-Base.hash(leg::JourneyLeg, h::UInt) = hash(
-    (
-        getfield(leg, :from_stop),
-        getfield(leg, :to_stop),
-        getfield(leg, :departure_time),
-        getfield(leg, :arrival_time),
-        getfield(leg, :fare),
-        getfield(leg, :trip).name,
+function Base.hash(leg::JourneyLeg, h::UInt)
+    return hash(
+        (
+            getfield(leg, :from_stop),
+            getfield(leg, :to_stop),
+            getfield(leg, :departure_time),
+            getfield(leg, :arrival_time),
+            getfield(leg, :fare),
+            getfield(leg, :trip).name,
+        ),
+        h,
     )
-    , h
-)
+end
 
 """Construct journey leg from option and to_stop"""
 function JourneyLeg(option::Option, to_stop::Stop)

--- a/src/raptor_algorithm/raptor_structs.jl
+++ b/src/raptor_algorithm/raptor_structs.jl
@@ -21,14 +21,14 @@ Bag(labels::Vector{Label}) = Bag([Option(label) for label in labels])
 struct McRaptorQuery
     origin::Station
     departure_time::DateTime
-    maximum_number_of_rounds::Int
+    maximum_transfers::Int
 end
 
 struct RangeMcRaptorQuery
     origin::Station
     departure_time_min::DateTime
     departure_time_max::DateTime
-    maximum_number_of_rounds::Int
+    maximum_transfers::Int
 end
 
 """Constructor where it trys to interpret the origin and destination string as a station"""
@@ -36,15 +36,15 @@ function McRaptorQuery(
     origin::String,
     departure_time::DateTime,
     timetable::TimeTable,
-    maximum_number_of_rounds::Integer,
+    maximum_transfers::Integer,
 )
     origin_station = try_to_get_station(origin, timetable)
-    return McRaptorQuery(origin_station, departure_time, maximum_number_of_rounds)
+    return McRaptorQuery(origin_station, departure_time, maximum_transfers)
 end
-"""Constructor where it trys to interpret the origin and destination string as a station and default 10 round"""
+"""Constructor where it trys to interpret the origin and destination string as a station and default 10 transfers"""
 function McRaptorQuery(origin::String, departure_time::DateTime, timetable::TimeTable)
-    maximum_number_of_rounds = 10
-    return McRaptorQuery(origin, departure_time, timetable, maximum_number_of_rounds)
+    maximum_transfers = 10
+    return McRaptorQuery(origin, departure_time, timetable, maximum_transfers)
 end
 
 function RangeMcRaptorQuery(
@@ -52,11 +52,11 @@ function RangeMcRaptorQuery(
     departure_time_min::DateTime,
     departure_time_max::DateTime,
     timetable::TimeTable,
-    maximum_number_of_rounds::Integer,
+    maximum_transfers::Integer,
 )
     origin_station = try_to_get_station(origin, timetable)
     return RangeMcRaptorQuery(
-        origin_station, departure_time_min, departure_time_max, maximum_number_of_rounds
+        origin_station, departure_time_min, departure_time_max, maximum_transfers
     )
 end
 
@@ -66,8 +66,8 @@ function RangeMcRaptorQuery(
     departure_time_max::DateTime,
     timetable::TimeTable,
 )
-    maximum_number_of_rounds = 10
+    maximum_transfers = 10
     return RangeMcRaptorQuery(
-        origin, departure_time_min, departure_time_max, timetable, maximum_number_of_rounds
+        origin, departure_time_min, departure_time_max, timetable, maximum_transfers
     )
 end

--- a/src/raptor_timetable/timetable_functions.jl
+++ b/src/raptor_timetable/timetable_functions.jl
@@ -117,9 +117,10 @@ function get_earliest_trip(
     return earliest_trip, earliest_departure_time
 end
 
-"""Collect all departure moments between t0 and t1 (inclusive)"""
-function departure_times(timetable::TimeTable, station::Station, t0::DateTime, t1::DateTime)
+"""Collect all departure moments between t0 and t1 (inclusive) and sort in descending order"""
+function descending_departure_times(timetable::TimeTable, station::Station, t0::DateTime, t1::DateTime)
     departures = timetable.station_departures_lookup[station.abbreviation.abbreviation]
     filter!(t -> t0 <= t <= t1, departures)
+    sort!(departures, rev=true)
     return departures
 end

--- a/src/raptor_timetable/timetable_functions.jl
+++ b/src/raptor_timetable/timetable_functions.jl
@@ -118,9 +118,11 @@ function get_earliest_trip(
 end
 
 """Collect all departure moments between t0 and t1 (inclusive) and sort in descending order"""
-function descending_departure_times(timetable::TimeTable, station::Station, t0::DateTime, t1::DateTime)
+function descending_departure_times(
+    timetable::TimeTable, station::Station, t0::DateTime, t1::DateTime
+)
     departures = timetable.station_departures_lookup[station.abbreviation.abbreviation]
     filter!(t -> t0 <= t <= t1, departures)
-    sort!(departures, rev=true)
+    sort!(departures; rev=true)
     return departures
 end

--- a/test/raptor_algorithm/test_reconstruction.jl
+++ b/test/raptor_algorithm/test_reconstruction.jl
@@ -1,0 +1,33 @@
+using Raptor
+using Dates
+using Logging
+using Test
+
+import Raptor: last_legs
+
+include("../create_test_timetable.jl")
+timetable = create_test_timetable();
+today = Date(2021, 10, 21)
+
+origin = "S2"
+departure_time = today + Time(13, 15);
+
+query = McRaptorQuery(origin, departure_time, timetable);
+
+bag_round_stop, last_round = run_mc_raptor(timetable, query);
+bag_last_round = bag_round_stop[last_round];
+
+# Test if last legs are correctly reconstructed
+destination = timetable.stations["S4"];
+journeys_with_last_legs = last_legs(destination, bag_last_round);
+@test length(journeys_with_last_legs) == 3
+
+# Again with only 2 rounds (0 transfers)
+query = McRaptorQuery(origin, departure_time, timetable, 2);
+bag_round_stop, last_round = run_mc_raptor(timetable, query);
+bag_last_round = bag_round_stop[last_round];
+
+destination = timetable.stations["S4"];
+journeys_with_last_legs = last_legs(destination, bag_last_round);
+@test length(journeys_with_last_legs) == 2
+

--- a/test/raptor_algorithm/test_reconstruction.jl
+++ b/test/raptor_algorithm/test_reconstruction.jl
@@ -22,8 +22,8 @@ destination = timetable.stations["S4"];
 journeys_with_last_legs = last_legs(destination, bag_last_round);
 @test length(journeys_with_last_legs) == 3
 
-# Again with only 2 rounds (0 transfers)
-query = McRaptorQuery(origin, departure_time, timetable, 2);
+# Again with only 0 transfers
+query = McRaptorQuery(origin, departure_time, timetable, 0);
 bag_round_stop, last_round = run_mc_raptor(timetable, query);
 bag_last_round = bag_round_stop[last_round];
 

--- a/test/raptor_algorithm/test_reconstruction.jl
+++ b/test/raptor_algorithm/test_reconstruction.jl
@@ -30,4 +30,3 @@ bag_last_round = bag_round_stop[last_round];
 destination = timetable.stations["S4"];
 journeys_with_last_legs = last_legs(destination, bag_last_round);
 @test length(journeys_with_last_legs) == 2
-

--- a/test/raptor_algorithm/test_run_range_mcraptor.jl
+++ b/test/raptor_algorithm/test_run_range_mcraptor.jl
@@ -4,7 +4,7 @@ using Logging
 using Test
 using JET
 
-# include("../create_test_timetable.jl")
+include("../create_test_timetable.jl")
 timetable = create_test_timetable();
 today = Date(2021, 10, 21)
 
@@ -15,10 +15,12 @@ departure_time_max = today + Time(20);
 range_query = RangeMcRaptorQuery(origin, departure_time_min, departure_time_max, timetable);
 journeys = run_mc_raptor_and_construct_journeys(timetable, range_query);
 
-destination = "S4"
-destination_station = try_to_get_station(destination, timetable);
 
-@test length(journeys[destination_station]) == 3
+destination_station_S4 = try_to_get_station("S4", timetable);
+@test length(journeys[destination_station_S4]) == 3
+
+destination_station_S7 = try_to_get_station("S7", timetable);
+@test length(journeys[destination_station_S7]) == 2
 
 @testset "type-stabilities (JET)" begin
     @test_opt target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(

--- a/test/raptor_algorithm/test_run_range_mcraptor.jl
+++ b/test/raptor_algorithm/test_run_range_mcraptor.jl
@@ -15,7 +15,6 @@ departure_time_max = today + Time(20);
 range_query = RangeMcRaptorQuery(origin, departure_time_min, departure_time_max, timetable);
 journeys = run_mc_raptor_and_construct_journeys(timetable, range_query);
 
-
 destination_station_S4 = try_to_get_station("S4", timetable);
 @test length(journeys[destination_station_S4]) == 3
 

--- a/test/raptor_timetable/test_timetable_functions.jl
+++ b/test/raptor_timetable/test_timetable_functions.jl
@@ -6,7 +6,7 @@ import Raptor: get_stop_idx_in_route, first_in_route
 import Raptor: get_stop_time, StopTime
 import Raptor: get_fare
 import Raptor: get_earliest_trip
-import Raptor: departure_times
+import Raptor: descending_departure_times
 
 using Test
 using Dates
@@ -60,6 +60,6 @@ expected_departure_time2 = today + Time(16, 1)
 @test actual_departure_time2 == expected_departure_time2
 
 t0 = today + Time(14)
-t1 = today + Time(16)
-expected_departures = [today + Time(14, 1)]
-@test departure_times(tt, tt.stations["S2"], t0, t1) == expected_departures
+t1 = today + Time(18)
+expected_departures = [today + Time(16, 1), today + Time(14, 1)]
+@test descending_departure_times(tt, tt.stations["S2"], t0, t1) == expected_departures


### PR DESCRIPTION
- Fix range mc raptor by looping through the departure dates in descending order instead of ascending.
- Fix hash of journeys such that unique works
- maximum_transfers in query instead of maximum_number_of_rounds

This fix made everything much slower.