### PR TITLE
Intercity direct costs extra and balanced multi-threading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,22 +10,22 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PProf = "e4faabce-9ead-11e9-39d9-4379958e3056"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
-CSV = "^0.10.14"
-DataFrames = "^1.6.1"
-JET = "0.9.9"
-JuliaFormatter = "^1.0.60"
+CSV = "^0.10.15"
+DataFrames = "^1.7.0"
+JuliaFormatter = "^1.0.62"
+JET = "0.9.18"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 
 [targets]
-test = ["Test", "Aqua"]
+test = ["Test", "Aqua", "JET"]

--- a/examples/range_mc_raptor_example.jl
+++ b/examples/range_mc_raptor_example.jl
@@ -27,4 +27,3 @@ journeys = @time main();
 println(journeys["AKM"]) # Akkrum
 println(journeys["GN"]) # Groningen
 println(journeys["ASDZ"]) # Amsterdam Zuid
-

--- a/examples/range_mc_raptor_example.jl
+++ b/examples/range_mc_raptor_example.jl
@@ -11,7 +11,7 @@ function main()
     date = Date(2024, 7, 1)
     timetable = load_timetable()
 
-    origin = "VS" # Vlissingen
+    origin = "BD" # Vlissingen
     departure_time_min = date + Time(0)
     departure_time_max = date + Time(23, 59)
 
@@ -26,3 +26,5 @@ journeys = @time main();
 
 println(journeys["AKM"]) # Akkrum
 println(journeys["GN"]) # Groningen
+println(journeys["ASDZ"]) # Amsterdam Zuid
+

--- a/examples/range_mc_raptor_example.jl
+++ b/examples/range_mc_raptor_example.jl
@@ -6,24 +6,22 @@ using Dates
 # date = Date(2024, 7, 1)
 # timetable = create_raptor_timetable(gtfs_dir, date);
 # save_timetable(timetable)
-
 function main()
     date = Date(2024, 7, 1)
     timetable = load_timetable()
 
-    origin = "BD" # Vlissingen
+    origin = "VS" # Vlissingen
     departure_time_min = date + Time(0)
     departure_time_max = date + Time(23, 59)
 
     range_query = RangeMcRaptorQuery(
         origin, departure_time_min, departure_time_max, timetable
     )
-    journeys = run_mc_raptor_and_construct_journeys(timetable, range_query)
+    journeys = @time run_mc_raptor_and_construct_journeys(timetable, range_query)
     return journeys
 end
 
-journeys = @time main();
+journeys = main();
 
 println(journeys["AKM"]) # Akkrum
 println(journeys["GN"]) # Groningen
-println(journeys["ASDZ"]) # Amsterdam Zuid

--- a/src/raptor_algorithm/raptor_structs.jl
+++ b/src/raptor_algorithm/raptor_structs.jl
@@ -33,10 +33,7 @@ end
 
 """Constructor where it trys to interpret the origin and destination string as a station"""
 function McRaptorQuery(
-    origin::String,
-    departure_time::DateTime,
-    timetable::TimeTable,
-    maximum_transfers::Integer,
+    origin::String, departure_time::DateTime, timetable::TimeTable, maximum_transfers::Int
 )
     origin_station = get_station(origin, timetable)
     return McRaptorQuery(origin_station, departure_time, maximum_transfers)
@@ -52,7 +49,7 @@ function RangeMcRaptorQuery(
     departure_time_min::DateTime,
     departure_time_max::DateTime,
     timetable::TimeTable,
-    maximum_transfers::Integer,
+    maximum_transfers::Int,
 )
     origin_station = get_station(origin, timetable)
     return RangeMcRaptorQuery(

--- a/src/raptor_timetable/timetable_creation.jl
+++ b/src/raptor_timetable/timetable_creation.jl
@@ -47,13 +47,21 @@ function create_trip(
     trip_name = triprow.trip_short_name
     trip_formula = triprow.trip_long_name
 
+    # Simplification of the fare calculation
+    # ICD fare of 3 euro.
+    if trip_formula == "Intercity direct"
+        fare = 3.0
+    else
+        fare = 0.0
+    end
+
     stops_in_trip_df = stop_times_with_trip_id(trip_id, gtfs_stop_times)
     sort!(stops_in_trip_df, [:arrival_time])
 
     stop_times = OrderedDict{String,StopTime}()
     for row in eachrow(stops_in_trip_df)
         stop = stops[row.stop_id]
-        stop_times[stop.id] = StopTime(stop, row.arrival_time, row.departure_time, 0.0)
+        stop_times[stop.id] = StopTime(stop, row.arrival_time, row.departure_time, fare)
     end
     route = Route([st.stop for st in values(stop_times)])
 

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -6,7 +6,7 @@ using Raptor
 Aqua.test_all(
     Raptor;
     ambiguities=false,
-    stale_deps=(ignore=[:Revise, :JuliaFormatter, :BenchmarkTools, :PProf, :JET],),
+    stale_deps=(ignore=[:JuliaFormatter, :BenchmarkTools, :PProf],),
     deps_compat=(
         check_extras=false,
         ignore=[


### PR DESCRIPTION
- Simplification of truth, but in the timetable a stopstop with an ICD costs 3 euro extra.
- Improve load balancing of multi-threading (when calculating all journey options)