### PR TITLE
Fix drive through issue in timetable

### DIFF
--- a/src/raptor_algorithm/construct_journeys.jl
+++ b/src/raptor_algorithm/construct_journeys.jl
@@ -49,8 +49,10 @@ function last_legs(destination::Station, bag_last_round)
 
     journeys = Journey[]
     for option in station_bag.options
-        # find the stop of the station at which the option arrives
-        to_stop = only(filter(s -> option in bag_last_round[s].options, to_stops))
+        # find the stop of the station at which the option arrives   
+        # sometimes the data contained a drive trough as stoptime
+        # in that case the filter wil return two stops we take the first
+        to_stop = first(filter(s -> option in bag_last_round[s].options, to_stops))
         clear_how_to_get_there =
             !isnothing(option.from_stop) &&
             !isnothing(option.from_departure_time) &&

--- a/src/raptor_algorithm/construct_journeys.jl
+++ b/src/raptor_algorithm/construct_journeys.jl
@@ -50,8 +50,11 @@ function last_legs(destination::Station, bag_last_round)
     journeys = Journey[]
     for option in station_bag.options
         # find the stop of the station at which the option arrives   
-        # sometimes the data contained a drive trough as stoptime
-        # in that case the filter wil return two stops we take the first
+        # If there is a drive through stopstop in the timetable:
+        # from one stop at the station to an other stop at the same station. 
+        # For example from ASD5b to ASD 5. Then an 'only' check failed. 
+        # Since arrival and departure time in the drive through are equal it
+        # doesnt matter which one you take, so we take first.
         to_stop = first(filter(s -> option in bag_last_round[s].options, to_stops))
         clear_how_to_get_there =
             !isnothing(option.from_stop) &&


### PR DESCRIPTION
If there is a drive through stopstop in the timetable from one stop at the station to an other stop at the same station. For example ASD5b to ASD 5. Then an 'only' check failed. It doesnt matter which one you take so take fist.

Time wise one could take the one that arrives first, but if it is a drive through the arrival and departure time are the same. So then the arrival times are equal of the to stoptimes.