### PR TITLE
Fix language server issue in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 	"features": {
 		// A Feature to install Julia via juliaup. More info: https://github.com/JuliaLang/devcontainer-features/tree/main/src/julia.
 		"ghcr.io/julialang/devcontainer-features/julia:1": {
-			"channel": "1.10" // consistent with the version in the Project.toml
+			"channel": "release" // language server wants the release version of Julia
 		}
 	},
 
@@ -18,12 +18,10 @@
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"julialang.language-julia"
-			]
+			],
 		}
 	},
 	"runArgs": [ "--env-file", ".devcontainer/variables.env" ],
-	"postCreateCommand": "bash .devcontainer/setup.sh",
+	"postCreateCommand": "bash .devcontainer/julia_setup.sh; .devcontainer/git_setup.sh",
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"	
 }

--- a/.devcontainer/git_setup.sh
+++ b/.devcontainer/git_setup.sh
@@ -3,8 +3,5 @@
 git config --global credential.https://dev.azure.com.useHttpPath true
 git config --global --add --bool push.autoSetupRemote true # dont need to do git push --set-upstream origin feature/branch anymore
 git config --global core.autocrlf input
-git config --global user.email "${GIT_MAIL}"
+git config --global user.email "${GIT_MAILLL}"
 git config --global user.name "${GIT_EMAIL}"
-julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate()'
-juliaup add release # for language server
-juliaup update

--- a/.devcontainer/julia_setup.sh
+++ b/.devcontainer/julia_setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+juliaup add 1.10 # consistent with the version in the Project.toml
+juliaup default 1.10
+julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate()'

--- a/Project.toml
+++ b/Project.toml
@@ -18,14 +18,14 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [compat]
 CSV = "^0.10.15"
 DataFrames = "^1.7.0"
-JuliaFormatter = "^1.0.62"
 JET = "0.9.18"
+JuliaFormatter = "^1.0.62"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Aqua", "JET"]


### PR DESCRIPTION
Guess: Since release version of julia is 1.11, VScode could not start the language server. Also not if release was separately installed. 
Now the container installs the release version, but the julia_setup script installs and sets 1.10 to default; which corresponds with the one in project.toml.