### PR TITLE
Bugfix/transfers

### DIFF
--- a/.devcontainer/git_setup.sh
+++ b/.devcontainer/git_setup.sh
@@ -3,5 +3,6 @@
 git config --global credential.https://dev.azure.com.useHttpPath true
 git config --global --add --bool push.autoSetupRemote true # dont need to do git push --set-upstream origin feature/branch anymore
 git config --global core.autocrlf input
-git config --global user.email "${GIT_MAILLL}"
-git config --global user.name "${GIT_EMAIL}"
+git config --global user.email "${GIT_EMAIL}"
+git config --global user.name "${GIT_NAME}"
+git config --global --add safe.directory /workspaces/Raptor.jl

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ See [Documentation](https://tjebbeh.github.io/Raptor.jl/) for instructions on ho
 ## TODO:
 - fix reconstruction of journeys without creating many duplicates
 - fix bug with number of transfers in label > number of transfers in journey
-- Check if number of transfers is needed in calculating pareto-set, or does this come for free because of the rounds?
 - Optimize (memory use)
 - More functional tests
 - Consider threshold, fares and default footpaths as input

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [Documentation](https://tjebbeh.github.io/Raptor.jl/) for instructions on ho
 ## TODO:
 - fix reconstruction of journeys without creating many duplicates
 - fix bug with number of transfers in label > number of transfers in journey
+- Parsing of gtfs does not always work correctly: sometimes there's different names for the same station
 - Optimize (memory use)
 - More functional tests
 - Consider threshold, fares and default footpaths as input

--- a/docs/src/mcraptor.md
+++ b/docs/src/mcraptor.md
@@ -36,7 +36,7 @@ To calculate the journey options we run the following code.
 ```julia
 bag_round_stop, last_round = run_mc_raptor(timetable, query);
 journeys = reconstruct_journeys_to_all_destinations(
-    query.origin, timetable, bag_round_stop, last_round
+    query, timetable, bag_round_stop, last_round
 );
 
 # Search for station with name Groningen

--- a/docs/src/toy_example.md
+++ b/docs/src/toy_example.md
@@ -35,7 +35,7 @@ query = McRaptorQuery(origin, departure_time, timetable)
 # Calculate all journey options departing from S2 at 13:15
 bag_round_stop, last_round = run_mc_raptor(timetable, query);
 journeys = reconstruct_journeys_to_all_destinations(
-    query.origin, timetable, bag_round_stop, last_round
+    query, timetable, bag_round_stop, last_round
 );
 
 # Print the journey options to S4

--- a/src/raptor_algorithm/construct_journeys.jl
+++ b/src/raptor_algorithm/construct_journeys.jl
@@ -10,7 +10,7 @@ function is_compatible_before(leg1::JourneyLeg, leg2::JourneyLeg)
             leg1.to_label.number_of_trips <= leg2.to_label.number_of_trips
     else
         number_of_trips_compatible =
-            leg1.to_label.number_of_trips < leg2.to_label.number_of_trips
+            leg1.to_label.number_of_trips + 1 == leg2.to_label.number_of_trips
     end
     only_one_is_transfer = !(is_transfer(leg1) & is_transfer(leg2))
     return time_compatible & number_of_trips_compatible & only_one_is_transfer

--- a/src/raptor_algorithm/construct_journeys.jl
+++ b/src/raptor_algorithm/construct_journeys.jl
@@ -91,31 +91,34 @@ function reconstruct_journeys_to_all_destinations(
 )
     destination_stations = Iterators.filter(!isequal(origin), values(timetable.stations))
     return Dict(
-        destination.abbreviation =>
-            reconstruct_journeys(origin, destination, bag_round_stop, last_round, max_nr_of_rounds) for
-        destination in destination_stations
+        destination.abbreviation => reconstruct_journeys(
+            origin, destination, bag_round_stop, last_round, max_nr_of_rounds
+        ) for destination in destination_stations
     )
 end
 
 """Reconstruct journeys to all destinations and append to journeys_to_destination dict"""
 function reconstruct_journeys_to_all_destinations!(
     journeys_to_destination::Dict{String,Vector{Journey}},
-    origin::Station,
+    query::McRaptorQuery,
     timetable::TimeTable,
     bag_round_stop,
     last_round,
-    max_nr_of_rounds
 )
+    origin = query.origin
+    maximum_rounds = query.maximum_transfers + 2
     destination_stations = Iterators.filter(!isequal(origin), values(timetable.stations))
     for destination in destination_stations
         if destination.abbreviation in keys(journeys_to_destination)
             append!(
                 journeys_to_destination[destination.abbreviation],
-                reconstruct_journeys(origin, destination, bag_round_stop, last_round, max_nr_of_rounds),
+                reconstruct_journeys(
+                    origin, destination, bag_round_stop, last_round, maximum_rounds
+                ),
             )
         else
             journeys_to_destination[destination.abbreviation] = reconstruct_journeys(
-                origin, destination, bag_round_stop, last_round, max_nr_of_rounds
+                origin, destination, bag_round_stop, last_round, maximum_rounds
             )
         end
     end

--- a/src/raptor_algorithm/raptor_functions.jl
+++ b/src/raptor_algorithm/raptor_functions.jl
@@ -371,7 +371,6 @@ function run_mc_raptor(
         maximum_rounds, values(timetable.stops), result_previous_run
     )
     initialize_round1!(bag_round_stop, query)
-
     marked_stops = Set{Stop}(query.origin.stops)
 
     last_round = 1
@@ -388,11 +387,13 @@ function run_mc_raptor(
 
         # Traverse routes serving marked stops from previous round
         marked_stops_by_train = traverse_routes!(bag_round_stop, k, timetable, marked_stops)
+        @debug "round $k: mark $(length(marked_stops_by_train)) train-stops"
 
         # Walk to other stops at stations of marked_stops
         marked_stops_by_walking = add_walking!(
             bag_round_stop, k, timetable, marked_stops_by_train
         )
+        @debug "round $k: mark $(length(marked_stops_by_walking)) walking-stops"
 
         # Combine marked stops
         marked_stops = union(marked_stops_by_train, marked_stops_by_walking)
@@ -430,7 +431,7 @@ function run_mc_raptor_and_construct_journeys(
         bag_round_stop, last_round = run_mc_raptor(timetable, query, last_round_bag)
         last_round_bag = deepcopy(bag_round_stop[last_round])
         reconstruct_journeys_to_all_destinations!(
-            journeys, query.origin, timetable, bag_round_stop, last_round
+            journeys, query.origin, timetable, bag_round_stop, last_round, query.maximum_transfers+1
         )
     end
     remove_duplicate_journeys!(journeys)

--- a/src/raptor_algorithm/raptor_functions.jl
+++ b/src/raptor_algorithm/raptor_functions.jl
@@ -431,7 +431,7 @@ function run_mc_raptor_and_construct_journeys(
         bag_round_stop, last_round = run_mc_raptor(timetable, query, last_round_bag)
         last_round_bag = deepcopy(bag_round_stop[last_round])
         reconstruct_journeys_to_all_destinations!(
-            journeys, query.origin, timetable, bag_round_stop, last_round, query.maximum_transfers+1
+            journeys, query, timetable, bag_round_stop, last_round
         )
     end
     remove_duplicate_journeys!(journeys)

--- a/src/raptor_algorithm/raptor_functions.jl
+++ b/src/raptor_algorithm/raptor_functions.jl
@@ -297,7 +297,7 @@ end
 function update_option(
     option::Option, from_stop::Stop, trip::Trip, departure_time::DateTime
 )
-    if option.trip_to_station != trip
+    if isnothing(option.trip_to_station) || option.trip_to_station.id != trip.id
         old_label = option.label
         new_label = Label(
             old_label.arrival_time, old_label.fare, old_label.number_of_trips + 1

--- a/test/raptor_algorithm/test_run_mcraptor.jl
+++ b/test/raptor_algorithm/test_run_mcraptor.jl
@@ -21,7 +21,7 @@ options42 = bag_round_stop[last_round][timetable.stops["s42"]].options
 @test minimum(o.label.number_of_trips for o in options42) == 1
 
 journeys = reconstruct_journeys_to_all_destinations(
-    query.origin, timetable, bag_round_stop, last_round
+    query, timetable, bag_round_stop, last_round
 );
 @test length(journeys["S4"]) == 3
 println(journeys["S4"]) # test if the dispatched Base.show functions run without error
@@ -29,12 +29,12 @@ println(journeys["S4"]) # test if the dispatched Base.show functions run without
 @testset "type-stabilities (JET)" begin
     @test_opt target_modules = (@__MODULE__,) run_mc_raptor(timetable, query)
     @test_opt target_modules = (@__MODULE__,) reconstruct_journeys_to_all_destinations(
-        query.origin, timetable, bag_round_stop, last_round
+        query, timetable, bag_round_stop, last_round
     )
 end
 @testset "code calls (JET)" begin
     @test_call target_modules = (@__MODULE__,) run_mc_raptor(timetable, query)
     @test_call target_modules = (@__MODULE__,) reconstruct_journeys_to_all_destinations(
-        query.origin, timetable, bag_round_stop, last_round
+        query, timetable, bag_round_stop, last_round
     )
 end


### PR DESCRIPTION
Bugfix where the reconstruction did not correctly reconstruct for range queries:
* Legs are only compatable when the number of transfers matches exactly
* We need to be able to reconstruct far enough back, so not only the number of steps before conversion of the last queried departure time. This is because sometimes, we want to reconstruct from a label that we carried over from a later departure time.
* Compare ID of stops instead of the whole struct (not sure if this contributed to a bug)