### PR TITLE
Bugfix - range query

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 CSV = "^0.10.15"
 DataFrames = "^1.7.0"
 JET = "0.9.18"
-JuliaFormatter = "^1.0.62"
+JuliaFormatter = "^2.1.0"
 julia = "1.10"
 
 [extras]

--- a/src/raptor_algorithm/raptor_functions.jl
+++ b/src/raptor_algorithm/raptor_functions.jl
@@ -10,11 +10,11 @@ Use result of previous round if available
 function initialize_bag_round_stop(
     maximum_rounds::Int,
     stops::Base.ValueIterator{Dict{String,Stop}},
-    result_previous_run::Union{Dict{Stop,Bag},Nothing},
+    result_previous_run::Union{Vector{Dict{Stop,Bag}},Nothing},
 )
     bag_round_stop = [create_stop_to_empty_bags(stops) for _ in 1:maximum_rounds]
     if !isnothing(result_previous_run)
-        bag_round_stop[1] = result_previous_run
+        bag_round_stop[1] = result_previous_run[1]
     end
     return bag_round_stop
 end
@@ -363,7 +363,7 @@ end
 function run_mc_raptor(
     timetable::TimeTable,
     query::McRaptorQuery,
-    result_previous_run::Union{Dict{Stop,Bag},Nothing}=nothing,
+    result_previous_run::Union{Vector{Dict{Stop,Bag}},Nothing}=nothing,
 )
     maximum_rounds = query.maximum_transfers + 2
     @debug "round 1: initialization"
@@ -379,6 +379,12 @@ function run_mc_raptor(
 
         # Copy bag from previous round
         bag_round_stop[k] = copy(bag_round_stop[k - 1])
+        for stop in keys(bag_round_stop[k])
+            if !isnothing(result_previous_run) && (stop in keys(result_previous_run[k]))
+                bag_round_stop[k][stop] = merge_bags(bag_round_stop[k][stop], result_previous_run[k][stop])
+            end
+        end
+
         if length(marked_stops) == 0
             @debug "no marked stops"
             break
@@ -425,11 +431,11 @@ function run_mc_raptor_and_construct_journeys(
         @info "calculating journey options for $(length(departure_times_from_origin)) departures from $(origin.name) ($(origin.abbreviation))"
     end
 
-    last_round_bag = nothing
+    previous_bag_round_stop = nothing
     for departure in departure_times_from_origin
         query = McRaptorQuery(origin, departure, maximum_transfers)
-        bag_round_stop, last_round = run_mc_raptor(timetable, query, last_round_bag)
-        last_round_bag = deepcopy(bag_round_stop[last_round])
+        bag_round_stop, last_round = run_mc_raptor(timetable, query, previous_bag_round_stop)
+        previous_bag_round_stop = bag_round_stop
         reconstruct_journeys_to_all_destinations!(
             journeys, query, timetable, bag_round_stop, last_round
         )

--- a/src/raptor_algorithm/raptor_functions.jl
+++ b/src/raptor_algorithm/raptor_functions.jl
@@ -379,9 +379,12 @@ function run_mc_raptor(
 
         # Copy bag from previous round
         bag_round_stop[k] = copy(bag_round_stop[k - 1])
+        # Merge bag for this round from previous run if available
         for stop in keys(bag_round_stop[k])
             if !isnothing(result_previous_run) && (stop in keys(result_previous_run[k]))
-                bag_round_stop[k][stop] = merge_bags(bag_round_stop[k][stop], result_previous_run[k][stop])
+                bag_round_stop[k][stop] = merge_bags(
+                    bag_round_stop[k][stop], result_previous_run[k][stop]
+                )
             end
         end
 
@@ -434,7 +437,9 @@ function run_mc_raptor_and_construct_journeys(
     previous_bag_round_stop = nothing
     for departure in departure_times_from_origin
         query = McRaptorQuery(origin, departure, maximum_transfers)
-        bag_round_stop, last_round = run_mc_raptor(timetable, query, previous_bag_round_stop)
+        bag_round_stop, last_round = run_mc_raptor(
+            timetable, query, previous_bag_round_stop
+        )
         previous_bag_round_stop = bag_round_stop
         reconstruct_journeys_to_all_destinations!(
             journeys, query, timetable, bag_round_stop, last_round

--- a/src/raptor_algorithm/raptor_functions.jl
+++ b/src/raptor_algorithm/raptor_functions.jl
@@ -179,8 +179,11 @@ different_options(b1::Bag, b2::Bag) = b1.options != b2.options
 """
 Merge bag for this round from previous run if available
 """
-function merge_bags_previous_result!(bag_round_stop::Vector{Dict{Stop,Bag}}, 
-    result_previous_run::Union{Vector{Dict{Stop,Bag}},Nothing}, k::Int)
+function merge_bags_previous_result!(
+    bag_round_stop::Vector{Dict{Stop,Bag}},
+    result_previous_run::Union{Vector{Dict{Stop,Bag}},Nothing},
+    k::Int,
+)
     for stop in keys(bag_round_stop[k])
         if !isnothing(result_previous_run) && (stop in keys(result_previous_run[k]))
             bag_round_stop[k][stop] = merge_bags(
@@ -395,9 +398,7 @@ function run_mc_raptor(
         # Copy bag from previous round
         bag_round_stop[k] = copy(bag_round_stop[k - 1])
         # Merge bag for this round from previous run if available
-        bag_round_stop = merge_bags_previous_result!(
-            bag_round_stop, result_previous_run, k
-        )
+        bag_round_stop = merge_bags_previous_result!(bag_round_stop, result_previous_run, k)
 
         if length(marked_stops) == 0
             @debug "no marked stops"

--- a/src/raptor_timetable/timetable_creation.jl
+++ b/src/raptor_timetable/timetable_creation.jl
@@ -1,8 +1,11 @@
 """Create dict of stops from gtfs stops dataframe"""
 function create_stops(gtfs_stops::DataFrame)
-    stops = Stop.(
-        String.(gtfs_stops.stop_id), gtfs_stops.stop_code, String.(gtfs_stops.platform_code)
-    )
+    stops =
+        Stop.(
+            String.(gtfs_stops.stop_id),
+            gtfs_stops.stop_code,
+            String.(gtfs_stops.platform_code),
+        )
     return Dict(stop.id => stop for stop in stops)
 end
 

--- a/src/raptor_timetable/timetable_creation.jl
+++ b/src/raptor_timetable/timetable_creation.jl
@@ -1,11 +1,8 @@
 """Create dict of stops from gtfs stops dataframe"""
 function create_stops(gtfs_stops::DataFrame)
-    stops =
-        Stop.(
-            String.(gtfs_stops.stop_id),
-            gtfs_stops.stop_code,
-            String.(gtfs_stops.platform_code),
-        )
+    stops = Stop.(
+        String.(gtfs_stops.stop_id), gtfs_stops.stop_code, String.(gtfs_stops.platform_code)
+    )
     return Dict(stop.id => stop for stop in stops)
 end
 

--- a/src/raptor_timetable/timetable_functions.jl
+++ b/src/raptor_timetable/timetable_functions.jl
@@ -105,11 +105,11 @@ function descending_departure_times(
     timetable::TimeTable, station::Station, t0::DateTime, t1::DateTime; sort_desc::Bool=true
 )
     departures = timetable.station_departures_lookup[station.abbreviation]
-    filter!(t -> t0 <= t <= t1, departures)
+    departures_within_range = filter(t -> t0 <= t <= t1, departures)
     if sort_desc
-        sort!(departures; rev=true)
+        sort!(departures_within_range; rev=true)
     end
-    return departures
+    return departures_within_range
 end
 
 """ Order stations in chuncks such that number of departures is balanced"""

--- a/test/create_test_timetable.jl
+++ b/test/create_test_timetable.jl
@@ -36,8 +36,8 @@ function create_test_timetable()
     stations = Dict(s.abbreviation => s for s in list_of_stations)
 
     list_of_routes = [
-        Route("r1", [stops[id] for id in ["s11", "s22", "s31", "s43", "s51"]]),
-        Route("r2", [stops[id] for id in ["s71", "s42", "s61"]]),
+        Route("r1", [stops[id] for id in ["s11", "s22", "s31", "s43", "s61"]]),
+        Route("r2", [stops[id] for id in ["s71", "s42", "s51"]]),
         Route("r3", [stops[id] for id in ["s22", "s72"]]),
         Route("r4", [stops[id] for id in ["s21", "s81", "s41"]]),
     ]

--- a/test/create_test_timetable2.jl
+++ b/test/create_test_timetable2.jl
@@ -1,0 +1,107 @@
+import Raptor: TimeTable, Stop, Trip, StopTime, Route, Station
+import Raptor: create_footpaths
+import Raptor: create_stop_routes_lookup, create_route_trip_lookup
+
+using Dates
+
+"""Create timetable for testing"""
+function create_test_timetable2()
+    list_of_stops = [
+        Stop("HT_1", "HT", "1"),
+        
+        Stop("UT_1", "UT", "1"),
+        Stop("UT_2", "UT", "2"),
+        
+        Stop("ASA_1", "ASA", "1"),
+        Stop("ASA_2", "ASA", "2"),
+        
+        Stop("ASB_1", "ASB", "1"),
+        Stop("ASB_2", "ASB", "2"),
+
+        Stop("AC_1", "AC", "1")
+    ]
+    stops = Dict(s.id => s for s in list_of_stops)
+
+    list_of_stations = [
+        Station("HT", "Den Bosch", [Stop("HT_1", "HT", "1")]),
+        Station("UT", "Utrecht", [Stop("UT_1", "UT", "1"), Stop("UT_2", "UT", "2")]),
+        Station("ASA", "Amsterdam Sloterdijk", [Stop("ASA_1", "ASA", "1"), Stop("ASA_2", "ASA", "2")]),
+        Station("ASB", "Amsterdam Bijlmer Arena", [Stop("ASB_1", "ASB", "1"), Stop("ASB_2", "ASB", "2")]),
+        Station("AC", "Amsterdam Centraal", [Stop("AC_1", "AC", "1")])
+    ]
+    stations = Dict(s.abbreviation => s for s in list_of_stations)
+
+    list_of_routes = [
+        Route("r1", [stops[id] for id in ["HT_1", "UT_1", "ASA_1"]]),
+        Route("r2", [stops[id] for id in ["ASA_2", "ASB_1", "AC_1"]]),
+        Route("r3", [stops[id] for id in ["UT_2", "ASB_2"]]),
+    ]
+    routes = Dict(r.id => r for r in list_of_routes)
+
+    today = Date(2021, 10, 21)
+    trip101 = Trip(
+        "t101",
+        "101",
+        "IC",
+        routes["r1"],
+        Dict(
+            "HT_1" => StopTime(stops["HT_1"], today + Time(9), today + Time(9, 1), 0.0),
+            "UT_1" => StopTime(stops["UT_1"], today + Time(10), today + Time(10, 1), 0.0),
+            "ASA_1" => StopTime(stops["ASA_1"], today + Time(11), today + Time(11, 1), 0.0),
+        ),
+    )
+    trip201 = Trip(
+        "t201",
+        "201",
+        "IC",
+        routes["r2"],
+        Dict(
+            "ASA_2" =>
+                StopTime(stops["ASA_2"], today + Time(11, 15), today + Time(11, 16), 0.0),
+            "ASB_1" =>
+                StopTime(stops["ASB_1"], today + Time(12), today + Time(12,1), 0.0),
+            "AC_1" =>
+                StopTime(stops["AC_1"], today + Time(13), today + Time(13,1), 0.0),
+        ),
+    )
+    trip301 = Trip(
+        "t301",
+        "301",
+        "Sprinter",
+        routes["r3"],
+        Dict(
+            "UT_2" => StopTime(stops["UT_2"], today + Time(10), today + Time(10,5), 0.0),
+            "ASB_2" => StopTime(stops["ASB_2"], today + Time(11), today + Time(11, 1), 0.0),
+        ),
+    )
+    list_of_trips = [trip101, trip201, trip301]
+    trips = Dict(t.id => t for t in list_of_trips)
+
+    # create_footpaths is tested so we use it here assuming it works
+    footpaths = create_footpaths(stations, 2.0 * 60)
+
+    stop_routes_lookup = create_stop_routes_lookup(list_of_stops, list_of_routes)
+    route_trip_lookup = create_route_trip_lookup(list_of_trips, list_of_routes)
+
+    station_departures_lookup = Dict(
+        "HT" => [today + Time(9,1)],
+        "UT" => [today + Time(10, 1), today + Time(10, 5)],
+        "ASA" => [today + Time(11, 1), today + Time(11, 16)],
+        "ASB" => [today + Time(11, 1), today + Time(12, 1)],
+        "AC" => [today + Time(13, 1)],
+    )
+
+    period = (first_arrival=today + Time(9,1), last_departure=today + Time(13, 1))
+
+    return TimeTable(
+        period,
+        stations,
+        stops,
+        trips,
+        routes,
+        footpaths,
+        stop_routes_lookup,
+        route_trip_lookup,
+        station_departures_lookup,
+    )
+end

--- a/test/create_test_timetable2.jl
+++ b/test/create_test_timetable2.jl
@@ -8,9 +8,12 @@ using Dates
 function create_test_timetable2()
     list_of_stops = [
         Stop("HT_1", "HT", "1"),
+        Stop("HT_2", "HT", "2"),
         
         Stop("UT_1", "UT", "1"),
         Stop("UT_2", "UT", "2"),
+        Stop("UT_3", "UT", "3"),
+
         
         Stop("ASA_1", "ASA", "1"),
         Stop("ASA_2", "ASA", "2"),
@@ -23,8 +26,8 @@ function create_test_timetable2()
     stops = Dict(s.id => s for s in list_of_stops)
 
     list_of_stations = [
-        Station("HT", "Den Bosch", [Stop("HT_1", "HT", "1")]),
-        Station("UT", "Utrecht", [Stop("UT_1", "UT", "1"), Stop("UT_2", "UT", "2")]),
+        Station("HT", "Den Bosch", [Stop("HT_1", "HT", "1"), Stop("HT_2", "HT", "2")]),
+        Station("UT", "Utrecht", [Stop("UT_1", "UT", "1"), Stop("UT_2", "UT", "2"), Stop("UT_3", "UT", "3")]),
         Station("ASA", "Amsterdam Sloterdijk", [Stop("ASA_1", "ASA", "1"), Stop("ASA_2", "ASA", "2")]),
         Station("ASB", "Amsterdam Bijlmer Arena", [Stop("ASB_1", "ASB", "1"), Stop("ASB_2", "ASB", "2")]),
         Station("AC", "Amsterdam Centraal", [Stop("AC_1", "AC", "1")])
@@ -35,6 +38,8 @@ function create_test_timetable2()
         Route("r1", [stops[id] for id in ["HT_1", "UT_1", "ASA_1"]]),
         Route("r2", [stops[id] for id in ["ASA_2", "ASB_1", "AC_1"]]),
         Route("r3", [stops[id] for id in ["UT_2", "ASB_2"]]),
+        Route("r4", [stops[id] for id in ["HT_2", "UT_3"]]),
+
     ]
     routes = Dict(r.id => r for r in list_of_routes)
 
@@ -42,7 +47,7 @@ function create_test_timetable2()
     trip101 = Trip(
         "t101",
         "101",
-        "IC",
+        "Sprinter",
         routes["r1"],
         Dict(
             "HT_1" => StopTime(stops["HT_1"], today + Time(9), today + Time(9, 1), 0.0),
@@ -53,7 +58,7 @@ function create_test_timetable2()
     trip201 = Trip(
         "t201",
         "201",
-        "IC",
+        "Sprinter",
         routes["r2"],
         Dict(
             "ASA_2" =>
@@ -70,8 +75,18 @@ function create_test_timetable2()
         "Sprinter",
         routes["r3"],
         Dict(
-            "UT_2" => StopTime(stops["UT_2"], today + Time(10), today + Time(10,5), 0.0),
+            "UT_2" => StopTime(stops["UT_2"], today + Time(10), today + Time(10,10), 0.0),
             "ASB_2" => StopTime(stops["ASB_2"], today + Time(11), today + Time(11, 1), 0.0),
+        ),
+    )
+    trip401 = Trip(
+        "t401",
+        "401",
+        "Sprinter",
+        routes["r3"],
+        Dict(
+            "HT_2" => StopTime(stops["HT_2"], today + Time(9), today + Time(9,30), 0.0),
+            "UT_3" => StopTime(stops["UT_3"], today + Time(10,5), today + Time(10,6), 0.0),
         ),
     )
     list_of_trips = [trip101, trip201, trip301]
@@ -84,8 +99,8 @@ function create_test_timetable2()
     route_trip_lookup = create_route_trip_lookup(list_of_trips, list_of_routes)
 
     station_departures_lookup = Dict(
-        "HT" => [today + Time(9,1)],
-        "UT" => [today + Time(10, 1), today + Time(10, 5)],
+        "HT" => [today + Time(9,1), today + Time(9,30)],
+        "UT" => [today + Time(10, 1), today + Time(10, 6), today + Time(10, 10)],
         "ASA" => [today + Time(11, 1), today + Time(11, 16)],
         "ASB" => [today + Time(11, 1), today + Time(12, 1)],
         "AC" => [today + Time(13, 1)],

--- a/test/create_test_timetable2.jl
+++ b/test/create_test_timetable2.jl
@@ -4,7 +4,19 @@ import Raptor: create_stop_routes_lookup, create_route_trip_lookup
 
 using Dates
 
-"""Create timetable for testing"""
+"""Create timetable for testing.
+This is based on a real world example where we have serveral lines serving the 
+stops HT, UT, ASA, ASB and AC. In, summary, we have:
+* line r1: HT_1 -> UT_1 -> ASA_1
+* line r2: ASA_2 -> ASB_1 -> AC_1
+* line r3: UT_2 -> ASB_2
+* line r4: HT_2 -> UT_3
+The timetable is as follows:    
+* trip t101: departs HT_1 at 09:01, arrives UT_1 at 10:01, arrives ASA_1 at 11:01
+* trip t201: departs ASA_2 at 11:15, arrives ASB_1 at 12:01, arrives AC_1 at 13:01
+* trip t301: departs UT_2 at 10:10, arrives ASB_2 at 11:01
+* trip t401: departs HT_2 at 09:30, arrives UT_3 at 10:06
+"""
 function create_test_timetable2()
     list_of_stops = [
         Stop("HT_1", "HT", "1"),

--- a/test/create_test_timetable2.jl
+++ b/test/create_test_timetable2.jl
@@ -83,13 +83,13 @@ function create_test_timetable2()
         "t401",
         "401",
         "Sprinter",
-        routes["r3"],
+        routes["r4"],
         Dict(
             "HT_2" => StopTime(stops["HT_2"], today + Time(9), today + Time(9,30), 0.0),
             "UT_3" => StopTime(stops["UT_3"], today + Time(10,5), today + Time(10,6), 0.0),
         ),
     )
-    list_of_trips = [trip101, trip201, trip301]
+    list_of_trips = [trip101, trip201, trip301, trip401]
     trips = Dict(t.id => t for t in list_of_trips)
 
     # create_footpaths is tested so we use it here assuming it works

--- a/test/create_test_timetable2.jl
+++ b/test/create_test_timetable2.jl
@@ -9,28 +9,35 @@ function create_test_timetable2()
     list_of_stops = [
         Stop("HT_1", "HT", "1"),
         Stop("HT_2", "HT", "2"),
-        
         Stop("UT_1", "UT", "1"),
         Stop("UT_2", "UT", "2"),
         Stop("UT_3", "UT", "3"),
-
-        
         Stop("ASA_1", "ASA", "1"),
         Stop("ASA_2", "ASA", "2"),
-        
         Stop("ASB_1", "ASB", "1"),
         Stop("ASB_2", "ASB", "2"),
-
-        Stop("AC_1", "AC", "1")
+        Stop("AC_1", "AC", "1"),
     ]
     stops = Dict(s.id => s for s in list_of_stops)
 
     list_of_stations = [
         Station("HT", "Den Bosch", [Stop("HT_1", "HT", "1"), Stop("HT_2", "HT", "2")]),
-        Station("UT", "Utrecht", [Stop("UT_1", "UT", "1"), Stop("UT_2", "UT", "2"), Stop("UT_3", "UT", "3")]),
-        Station("ASA", "Amsterdam Sloterdijk", [Stop("ASA_1", "ASA", "1"), Stop("ASA_2", "ASA", "2")]),
-        Station("ASB", "Amsterdam Bijlmer Arena", [Stop("ASB_1", "ASB", "1"), Stop("ASB_2", "ASB", "2")]),
-        Station("AC", "Amsterdam Centraal", [Stop("AC_1", "AC", "1")])
+        Station(
+            "UT",
+            "Utrecht",
+            [Stop("UT_1", "UT", "1"), Stop("UT_2", "UT", "2"), Stop("UT_3", "UT", "3")],
+        ),
+        Station(
+            "ASA",
+            "Amsterdam Sloterdijk",
+            [Stop("ASA_1", "ASA", "1"), Stop("ASA_2", "ASA", "2")],
+        ),
+        Station(
+            "ASB",
+            "Amsterdam Bijlmer Arena",
+            [Stop("ASB_1", "ASB", "1"), Stop("ASB_2", "ASB", "2")],
+        ),
+        Station("AC", "Amsterdam Centraal", [Stop("AC_1", "AC", "1")]),
     ]
     stations = Dict(s.abbreviation => s for s in list_of_stations)
 
@@ -39,7 +46,6 @@ function create_test_timetable2()
         Route("r2", [stops[id] for id in ["ASA_2", "ASB_1", "AC_1"]]),
         Route("r3", [stops[id] for id in ["UT_2", "ASB_2"]]),
         Route("r4", [stops[id] for id in ["HT_2", "UT_3"]]),
-
     ]
     routes = Dict(r.id => r for r in list_of_routes)
 
@@ -63,10 +69,8 @@ function create_test_timetable2()
         Dict(
             "ASA_2" =>
                 StopTime(stops["ASA_2"], today + Time(11, 15), today + Time(11, 16), 0.0),
-            "ASB_1" =>
-                StopTime(stops["ASB_1"], today + Time(12), today + Time(12,1), 0.0),
-            "AC_1" =>
-                StopTime(stops["AC_1"], today + Time(13), today + Time(13,1), 0.0),
+            "ASB_1" => StopTime(stops["ASB_1"], today + Time(12), today + Time(12, 1), 0.0),
+            "AC_1" => StopTime(stops["AC_1"], today + Time(13), today + Time(13, 1), 0.0),
         ),
     )
     trip301 = Trip(
@@ -75,7 +79,7 @@ function create_test_timetable2()
         "Sprinter",
         routes["r3"],
         Dict(
-            "UT_2" => StopTime(stops["UT_2"], today + Time(10), today + Time(10,10), 0.0),
+            "UT_2" => StopTime(stops["UT_2"], today + Time(10), today + Time(10, 10), 0.0),
             "ASB_2" => StopTime(stops["ASB_2"], today + Time(11), today + Time(11, 1), 0.0),
         ),
     )
@@ -85,8 +89,9 @@ function create_test_timetable2()
         "Sprinter",
         routes["r4"],
         Dict(
-            "HT_2" => StopTime(stops["HT_2"], today + Time(9), today + Time(9,30), 0.0),
-            "UT_3" => StopTime(stops["UT_3"], today + Time(10,5), today + Time(10,6), 0.0),
+            "HT_2" => StopTime(stops["HT_2"], today + Time(9), today + Time(9, 30), 0.0),
+            "UT_3" =>
+                StopTime(stops["UT_3"], today + Time(10, 5), today + Time(10, 6), 0.0),
         ),
     )
     list_of_trips = [trip101, trip201, trip301, trip401]
@@ -99,14 +104,14 @@ function create_test_timetable2()
     route_trip_lookup = create_route_trip_lookup(list_of_trips, list_of_routes)
 
     station_departures_lookup = Dict(
-        "HT" => [today + Time(9,1), today + Time(9,30)],
+        "HT" => [today + Time(9, 1), today + Time(9, 30)],
         "UT" => [today + Time(10, 1), today + Time(10, 6), today + Time(10, 10)],
         "ASA" => [today + Time(11, 1), today + Time(11, 16)],
         "ASB" => [today + Time(11, 1), today + Time(12, 1)],
         "AC" => [today + Time(13, 1)],
     )
 
-    period = (first_arrival=today + Time(9,1), last_departure=today + Time(13, 1))
+    period = (first_arrival=today + Time(9, 1), last_departure=today + Time(13, 1))
 
     return TimeTable(
         period,

--- a/test/raptor_algorithm/test_run_range_mcraptor.jl
+++ b/test/raptor_algorithm/test_run_range_mcraptor.jl
@@ -2,10 +2,36 @@ using Raptor
 using Dates
 using Logging
 using Test
-using JET
+# using JET
 
-# include("../create_test_timetable.jl")
-timetable = create_test_timetable();
+# # include("../create_test_timetable.jl")
+# timetable = create_test_timetable();
+# today = Date(2021, 10, 21)
+
+# origin = "S2"
+# departure_time_min = today + Time(8);
+# departure_time_max = today + Time(20);
+
+# range_query = RangeMcRaptorQuery(origin, departure_time_min, departure_time_max, timetable);
+# journeys = run_mc_raptor_and_construct_journeys(timetable, range_query);
+
+# @test length(journeys["S4"]) == 3
+# @test length(journeys["S7"]) == 2
+
+# @testset "type-stabilities (JET)" begin
+#     @test_opt target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(
+#         timetable, range_query
+#     )
+# end
+# @testset "code calls (JET)" begin
+#     @test_call target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(
+#         timetable, range_query
+#     )
+# end
+
+
+include("../create_test_timetable2.jl")
+timetable = create_test_timetable2();
 today = Date(2021, 10, 21)
 
 origin = "S2"
@@ -17,14 +43,3 @@ journeys = run_mc_raptor_and_construct_journeys(timetable, range_query);
 
 @test length(journeys["S4"]) == 3
 @test length(journeys["S7"]) == 2
-
-@testset "type-stabilities (JET)" begin
-    @test_opt target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(
-        timetable, range_query
-    )
-end
-@testset "code calls (JET)" begin
-    @test_call target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(
-        timetable, range_query
-    )
-end

--- a/test/raptor_algorithm/test_run_range_mcraptor.jl
+++ b/test/raptor_algorithm/test_run_range_mcraptor.jl
@@ -2,36 +2,11 @@ using Raptor
 using Dates
 using Logging
 using Test
-# using JET
+import Raptor:is_transfer
+using JET
 
-# # include("../create_test_timetable.jl")
-# timetable = create_test_timetable();
-# today = Date(2021, 10, 21)
-
-# origin = "S2"
-# departure_time_min = today + Time(8);
-# departure_time_max = today + Time(20);
-
-# range_query = RangeMcRaptorQuery(origin, departure_time_min, departure_time_max, timetable);
-# journeys = run_mc_raptor_and_construct_journeys(timetable, range_query);
-
-# @test length(journeys["S4"]) == 3
-# @test length(journeys["S7"]) == 2
-
-# @testset "type-stabilities (JET)" begin
-#     @test_opt target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(
-#         timetable, range_query
-#     )
-# end
-# @testset "code calls (JET)" begin
-#     @test_call target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(
-#         timetable, range_query
-#     )
-# end
-
-
-include("../create_test_timetable2.jl")
-timetable = create_test_timetable2();
+# include("../create_test_timetable.jl")
+timetable = create_test_timetable();
 today = Date(2021, 10, 21)
 
 origin = "S2"
@@ -43,3 +18,38 @@ journeys = run_mc_raptor_and_construct_journeys(timetable, range_query);
 
 @test length(journeys["S4"]) == 3
 @test length(journeys["S7"]) == 2
+
+@testset "type-stabilities (JET)" begin
+    @test_opt target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(
+        timetable, range_query
+    )
+end
+@testset "code calls (JET)" begin
+    @test_call target_modules = (@__MODULE__,) run_mc_raptor_and_construct_journeys(
+        timetable, range_query
+    )
+end
+
+
+include("../create_test_timetable2.jl")
+timetable = create_test_timetable2();
+today = Date(2021, 10, 21)
+
+origin = "HT"
+departure_time_min = today + Time(9,0);
+departure_time_max = today + Time(20);
+
+range_query = RangeMcRaptorQuery(origin, departure_time_min, departure_time_max, timetable);
+journeys = run_mc_raptor_and_construct_journeys(timetable, range_query);
+
+# We expect two possible journeys from HT to AC:
+# One with an earlier departure time but only 1 transfer in ASA
+# One with a later departure time and 2 transfers, arriving at the same time as the other journey
+print(journeys["AC"])
+@test length(journeys["AC"]) == 2
+
+# Because departure times are sorted reversly, the last found journey is the one that departs the earliest
+earliest_journey = journeys["AC"][end]
+@test length(earliest_journey.legs) == 3
+@test [leg.trip.name for leg in earliest_journey.legs if !is_transfer(leg)] == ["101","201"]
+@test earliest_journey.legs[end].to_label.number_of_trips == 2

--- a/test/raptor_algorithm/test_run_range_mcraptor.jl
+++ b/test/raptor_algorithm/test_run_range_mcraptor.jl
@@ -2,7 +2,7 @@ using Raptor
 using Dates
 using Logging
 using Test
-import Raptor:is_transfer
+import Raptor: is_transfer
 using JET
 
 # include("../create_test_timetable.jl")
@@ -30,13 +30,12 @@ end
     )
 end
 
-
 include("../create_test_timetable2.jl")
 timetable = create_test_timetable2();
 today = Date(2021, 10, 21)
 
 origin = "HT"
-departure_time_min = today + Time(9,0);
+departure_time_min = today + Time(9, 0);
 departure_time_max = today + Time(20);
 
 range_query = RangeMcRaptorQuery(origin, departure_time_min, departure_time_max, timetable);
@@ -51,5 +50,5 @@ print(journeys["AC"])
 # Because departure times are sorted reversly, the last found journey is the one that departs the earliest
 earliest_journey = journeys["AC"][end]
 @test length(earliest_journey.legs) == 3
-@test [leg.trip.name for leg in earliest_journey.legs if !is_transfer(leg)] == ["101","201"]
+@test [leg.trip.name for leg in earliest_journey.legs if !is_transfer(leg)] == ["101", "201"]
 @test earliest_journey.legs[end].to_label.number_of_trips == 2

--- a/test/raptor_algorithm/test_run_range_mcraptor.jl
+++ b/test/raptor_algorithm/test_run_range_mcraptor.jl
@@ -30,7 +30,7 @@ end
     )
 end
 
-include("../create_test_timetable2.jl")
+# include("../create_test_timetable2.jl")
 timetable = create_test_timetable2();
 today = Date(2021, 10, 21)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ import Logging: Warn, ConsoleLogger, with_logger
 @testset "Tests" verbose = true begin
     with_logger(ConsoleLogger(stderr, Warn)) do
         include("./create_test_timetable.jl")
+        include("./create_test_timetable2.jl")
 
         @testset "Aqua quality assurance test" verbose = true begin
             include("./aqua.jl")


### PR DESCRIPTION
The range query worked incorrectly, because results from the last round of the later departure time were copied to the bag of the first round. This meant we got competing labels with more transfers than the maximum in this round.
We fix this by merging only the labels from round k from the previous run in the bag of round k.
A test (based on a real-world example) is added to represent the situation where the bug resulted in a non-optimal set of options.